### PR TITLE
Add `_` as allowed character in usernameRegexp

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -12,7 +12,7 @@ import (
 var (
 	emailRegexp    = regexp.MustCompile(`\A[A-Z0-9a-z\._%\+\-]+@[A-Za-z0-9\.\-]+\.[A-Za-z]{2,6}\z`)
 	teamRegexp     = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+\/[a-zA-Z0-9_\-]+)\z`)
-	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+)\z`)
+	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-_]+)\z`)
 )
 
 const (


### PR DESCRIPTION
While generally disallowed from public github usernames, an underscore is a key part of github EMU usernames. See
https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/understanding-iam-for-enterprises/about-enterprise-managed-users for more information.